### PR TITLE
update ations

### DIFF
--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Run pre-commits
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.1

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -6,9 +6,6 @@
 
 name: Code Quality PR
 
-env:
-  SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL: True
-
 on:
   pull_request:
     branches: [main, "release/*"]
@@ -19,23 +16,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v6
         with:
-          python-version: "3.12"
-
-      - name: Find modified files
-        id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
-        with:
-          output: " "
-
-      - name: List modified files
-        run: echo '${{ steps.file_changes.outputs.files}}'
+          python-version: "3.13"
 
       - name: Run pre-commits
-        uses: pre-commit/action@v2.0.3
-        with:
-          extra_args: --files ${{ steps.file_changes.outputs.files}}
+        uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
## Summary by Sourcery

Update code-quality GitHub Actions workflows to use latest action versions and Python 3.13, and clean up obsolete steps and environment variables

Enhancements:
- Bump actions/checkout to v5, setup-python to v6, and pre-commit/action to v3.0.1 in both PR and main workflows
- Update default Python version from 3.12 to 3.13
- Remove file-changes-action and associated listing steps from the PR workflow
- Drop deprecated SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL environment variable